### PR TITLE
フォグスクリプトを軽量化

### DIFF
--- a/天候プラグイン/フォグスクリプト_彩羽.js
+++ b/天候プラグイン/フォグスクリプト_彩羽.js
@@ -67,6 +67,7 @@
   }
 
   ■バージョン履歴
+  2022/03/08  計算量やrootメソッドの呼び出し回数を減らして動作を軽量化
   2022/02/12  マップロード時に画像キャッシュを破棄する処理を追加（マップをまたいで天候が保持されてしまうバグを解消）
   2022/02/02  30FPSに対応
   2022/02/02  新規作成
@@ -92,14 +93,10 @@ CacheControl._FogPic = null;
 
 CacheControl.initialize_FogPic = function() {
   this._FogPic = null;
-}
+};
 
-CacheControl.get_FogPic = function() {
+CacheControl.get_FogPic = function(fog_info) {
   var pic;
-  var fog_info = MapLayer._getFogInfo();
-  if (!fog_info) {
-    return;
-  }
 
 	if (!this._FogPic) {
 		pic = root.getMaterialManager().createImage('FogImage', fog_info.FOG_IMAGE_NAME);
@@ -165,15 +162,23 @@ MapLayer.prepareMapLayer = function() {
     return;
   }
 
+  var pic = CacheControl.get_FogPic(fog_info);
+  var picSize = Math.max(pic.getWidth(), pic.getHeight());
+  var fogAreaWidth = root.getGameAreaWidth() + picSize * 2;
+  var fogAreaHeight = root.getGameAreaHeight() + picSize * 2;
+  //30FPSの場合は速さを2倍に
+  var highPerformanceCorrection = DataConfig.isHighPerformance() ? 1 : 2;
+  fog_info.FOG_SPEED_MAX *= highPerformanceCorrection;
+  fog_info.FOG_SPEED_MIN *= highPerformanceCorrection;
+  var scaleRange = fog_info.FOG_SCALE_MAX - fog_info.FOG_SCALE_MIN;
+  var angleRange = fog_info.FOG_ANGLE_MAX - fog_info.FOG_ANGLE_MIN;
+  var speedRange = fog_info.FOG_SPEED_MAX - fog_info.FOG_SPEED_MIN;
   for (var i = 0; i < fog_info.FOG_COUNT; i++) {
-    var pic = CacheControl.get_FogPic();
-    var picsize = Math.max(pic.getWidth(), pic.getHeight());
- 
-    this._FogX[i] = Math.random() * (root.getGameAreaWidth() + picsize * 2) - picsize;
-    this._FogY[i] = Math.random() * (root.getGameAreaHeight() + picsize * 2) - picsize;
-    this._FogScale[i] = Math.random() * (fog_info.FOG_SCALE_MAX - fog_info.FOG_SCALE_MIN) + fog_info.FOG_SCALE_MIN;
-    this._FogAngle[i] = Math.random() * (fog_info.FOG_ANGLE_MAX - fog_info.FOG_ANGLE_MIN) + fog_info.FOG_ANGLE_MIN;
-    this._FogSpeed[i] = Math.random() * (fog_info.FOG_SPEED_MAX - fog_info.FOG_SPEED_MIN) + fog_info.FOG_SPEED_MIN;
+    this._FogX[i] = Math.random() * fogAreaWidth - picSize;
+    this._FogY[i] = Math.random() * fogAreaHeight - picSize;
+    this._FogScale[i] = Math.random() * scaleRange + fog_info.FOG_SCALE_MIN;
+    this._FogAngle[i] = Math.random() * angleRange + fog_info.FOG_ANGLE_MIN;
+    this._FogSpeed[i] = Math.random() * speedRange + fog_info.FOG_SPEED_MIN;
   }
 };
 
@@ -183,43 +188,51 @@ MapLayer.moveMapLayer = function() {
   if (!fog_info) {
     return alias01.call(this);
   }
-  if (!this._isEnableLocalSwitchFog()) {
+  if (!this._isEnableLocalSwitchFog(fog_info)) {
     return alias01.call(this);
   }
 
-  var pic = CacheControl.get_FogPic();
+  var pic = CacheControl.get_FogPic(fog_info);
+  var picWidth = pic.getWidth();
+  var picHeight = pic.getHeight();
+  var fogAreaLeftEdge = -1 * picWidth;
+  var fogAreaTopEdge = -1 * picHeight;
+  var fogAreaRightEdge = picWidth + root.getGameAreaWidth();
+  var fogAreaBottomEdge =  picHeight + root.getGameAreaHeight();
+
   for (var i = 0; i < fog_info.FOG_COUNT; i++) {
-
-    var speed = this._FogSpeed[i];
-    //30FPSの場合は速さを2倍に
-    if (!DataConfig.isHighPerformance()) {
-      speed *= 2;
-		}
-
-    this._FogX[i] += Math.cos(this._FogAngle[i]) * speed;
-    this._FogY[i] += Math.sin(this._FogAngle[i]) * speed;
-  
     this._FogAngle[i] += (Math.random() - 0.5) * fog_info.FOG_ANGLE_VAR;
-    this._FogAngle[i] = Math.max(this._FogAngle[i], fog_info.FOG_ANGLE_MIN);
-    this._FogAngle[i] = Math.min(this._FogAngle[i], fog_info.FOG_ANGLE_MAX);
+
+    if (this._FogAngle[i] > fog_info.FOG_ANGLE_MAX) {
+      this._FogAngle[i] = fog_info.FOG_ANGLE_MAX;
+    }
+    else if (this._FogAngle[i] < fog_info.FOG_ANGLE_MIN) {
+      this._FogAngle[i] = fog_info.FOG_ANGLE_MIN;
+    }
 
     this._FogSpeed[i] += (Math.random() - 0.5) * fog_info.FOG_SPEED_VAR;
-    this._FogSpeed[i] = Math.max(this._FogSpeed[i], fog_info.FOG_SPEED_MIN);
-    this._FogSpeed[i] = Math.min(this._FogSpeed[i], fog_info.FOG_SPEED_MAX);
+    if (this._FogSpeed[i] > fog_info.FOG_SPEED_MAX) {
+      this._FogSpeed[i] = fog_info.FOG_SPEED_MAX;
+    }
+    else if (this._FogSpeed[i] < fog_info.FOG_SPEED_MIN) {
+      this._FogSpeed[i] = fog_info.FOG_SPEED_MIN;
+    }
+    
+    this._FogX[i] += Math.cos(this._FogAngle[i]) * this._FogSpeed[i];
+    this._FogY[i] += Math.sin(this._FogAngle[i]) * this._FogSpeed[i];
 
     // 画面外に出たら、反対側にワープ
-    var picsize = Math.max(pic.getWidth(), pic.getHeight());
-    if (this._FogX[i] > root.getGameAreaWidth() + picsize) {
-      this._FogX[i] = -1 * picsize;
+    if (this._FogX[i] > fogAreaRightEdge) {
+      this._FogX[i] = fogAreaLeftEdge;
     }
-    if (this._FogX[i] < - picsize) {
-      this._FogX[i] = root.getGameAreaWidth() + picsize;
+    else if (this._FogX[i] < fogAreaLeftEdge) {
+      this._FogX[i] = fogAreaRightEdge;
     }
-    if (this._FogY[i] > root.getGameAreaHeight() + picsize) {
-      this._FogY[i] = -1 * picsize;
+    if (this._FogY[i] > fogAreaBottomEdge) {
+      this._FogY[i] = fogAreaTopEdge;
     }
-    if (this._FogY[i] < - picsize) {
-      this._FogY[i] = root.getGameAreaHeight() + picsize;
+    else if (this._FogY[i] < fogAreaTopEdge) {
+      this._FogY[i] = fogAreaBottomEdge;
     }
   }
 
@@ -234,15 +247,16 @@ MapLayer.drawUnitLayer = function() {
   if (!fog_info) {
     return;
   }
-  if (!this._isEnableLocalSwitchFog()) {
+  if (!this._isEnableLocalSwitchFog(fog_info)) {
     return;
   }
 
-  var pic = CacheControl.get_FogPic();
+  var pic = CacheControl.get_FogPic(fog_info);
+  var AngleCorrection = 180 / Math.PI;
   for (var i = 0; i < fog_info.FOG_COUNT; i++) {
     pic.draw(this._FogX[i], this._FogY[i]);
     pic.setScale(this._FogScale[i]);
-    pic.setDegree(this._FogAngle[i] * 180 / Math.PI);
+    pic.setDegree(this._FogAngle[i] * AngleCorrection);
   }
 };
 
@@ -262,11 +276,9 @@ MapLayer._getFogInfo = function() {
 	return fog_info;
 };
 
-MapLayer._isEnableLocalSwitchFog = function() {
-  var currentMapInfo = root.getCurrentSession().getCurrentMapInfo();
-  var fog_info = currentMapInfo.custom.iroha_fog;
-
+MapLayer._isEnableLocalSwitchFog = function(fog_info) {
   if (fog_info.SWITCH_ID != null) {
+    var currentMapInfo = root.getCurrentSession().getCurrentMapInfo();
     var localSwitchTable = currentMapInfo.getLocalSwitchTable();
     var switchIndex = localSwitchTable.getSwitchIndexFromId(fog_info.SWITCH_ID);
     if (!localSwitchTable.isSwitchOn(switchIndex)) {
@@ -278,4 +290,3 @@ MapLayer._isEnableLocalSwitchFog = function() {
 }
 
 })();
-

--- a/天候プラグイン/フォグスクリプト_彩羽.js
+++ b/天候プラグイン/フォグスクリプト_彩羽.js
@@ -252,11 +252,11 @@ MapLayer.drawUnitLayer = function() {
   }
 
   var pic = CacheControl.get_FogPic(fog_info);
-  var AngleCorrection = 180 / Math.PI;
+  var angleCorrection = 180 / Math.PI;
   for (var i = 0; i < fog_info.FOG_COUNT; i++) {
     pic.draw(this._FogX[i], this._FogY[i]);
     pic.setScale(this._FogScale[i]);
-    pic.setDegree(this._FogAngle[i] * AngleCorrection);
+    pic.setDegree(this._FogAngle[i] * angleCorrection);
   }
 };
 


### PR DESCRIPTION
## 概要
フォグスクリプトでrootメソッドの呼び出し、冗長と思われる計算処理を削減しました。
本スクリプトは毎フレーム何百回も画像描画命令が出るため、
どうしてもゲームのパフォーマンスが低下してしまいますがこの修正である程度の改善が期待できます。
※ コードを綺麗に整えるよりもパフォーマンス面を重視しております。

なにか元のスクリプトと異なる挙動になってしまう箇所がありましたら、ご指摘お願いしますー！🙇

## やったこと
### `CacheControl.get_FogPic`、`_isEnableLocalSwitchFog`の引数にフォグのカスパラを追加
どの呼び出しでも事前にフォグのカスタムパラメータを取得している事から、
もう一度`root.getCurrentSession().getCurrentMapInfo()`を呼び出す必要は無いため引数として値を渡してもらう形にした。

### 30FPS時の補正計算をfor文の外へ移行
`DataConfig.isHighPerformance()`の呼び出しは1フレーム1回、補正の乗算は1フレーム2回に軽減した。
他にもfor文内で同じ計算を行っている箇所は全て外に出した。

### for文内の各種フォグ設定値の補正をなるべく計算回数が少なくなるように記述
毎フレームにおける`_FogSpeed`、`_FogAngle`の最小値-最大値内でおさめるロジックについて、
可読性が悪くなるがパフォーマンス優先で`if-else`文に変更した。

※別の関数にして最小値～最大値に収めるロジックを共通化させた場合、for文内で何度も関数呼び出しを行う事でかえってパフォーマンスが低下する事を確認したので見送った。